### PR TITLE
Ignore comments

### DIFF
--- a/src/GraphQL/GraphQL.g4
+++ b/src/GraphQL/GraphQL.g4
@@ -201,3 +201,4 @@ fragment INT :   '0' | [1-9] [0-9]* ; // no leading zeros
 fragment EXP :   [Ee] [+\-]? INT ; // \- since - means "range" inside [...]
 WS  :   [ \t\n\r]+ -> skip ;
 COMMA  :   [,]+ -> skip ;
+COMMENT  :   '#' ~[\r\n\u2028\u2029]* -> skip ;


### PR DESCRIPTION
GraphiQL starts up with a large comment at the top of the query.
Previously, if you had typed a query below the comments and executed it,
you would have received an "Unknown operation name:" error.