### PR TITLE
Upgrade Fixie to fix VS2015 Test Explorer issue

### DIFF
--- a/src/GraphQL.Tests/GraphQL.Tests.csproj
+++ b/src/GraphQL.Tests/GraphQL.Tests.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Fixie, Version=1.0.0.15, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Fixie.1.0.0.15\lib\net45\Fixie.dll</HintPath>
+    <Reference Include="Fixie, Version=1.0.0.29, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Fixie.1.0.0.29\lib\net45\Fixie.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/GraphQL.Tests/packages.config
+++ b/src/GraphQL.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Fixie" version="1.0.0.15" targetFramework="net45" userInstalled="true" />
+  <package id="Fixie" version="1.0.0.29" targetFramework="net45" userInstalled="true" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" userInstalled="true" />
   <package id="Should" version="1.1.20" targetFramework="net45" userInstalled="true" />
 </packages>


### PR DESCRIPTION
I received a "Microsoft.Cci.Pdb.PdbDebugException: Unknown custom
metadata item kind: 7" error when performing a "Rebuild All" in Visual
Studio 2015 with Fixie.

The problem went away after upgrading to 1.0.0.29 and restarting Visual
Studio. I can now double click on the test in Test Explorer and it will
jump to the test where I can then use the built-in test runner.